### PR TITLE
add-version script now updates the readme version examples correctly.

### DIFF
--- a/Casks/g/galasactl.rb
+++ b/Casks/g/galasactl.rb
@@ -9,7 +9,7 @@ cask "galasactl" do
   url "https://github.com/galasa-dev/cli/releases/download/v#{version}/galasactl-darwin-#{arch}",
       verified: "github.com/galasa-dev/cli/releases/"
   name "Galasa Client"
-  desc "Client to interact with the Galasa ecosystem or local development environment. Latest version"
+  desc "Command-line client for Galasa. Latest version"
   homepage "https://galasa.dev/"
 
   livecheck do

--- a/Casks/g/galasactl@0.36.0.rb
+++ b/Casks/g/galasactl@0.36.0.rb
@@ -9,7 +9,7 @@ cask "galasactl@0.36.0" do
   url "https://github.com/galasa-dev/cli/releases/download/v#{version}/galasactl-darwin-#{arch}",
       verified: "github.com/galasa-dev/cli/releases/"
   name "Galasa Client"
-  desc "Client to interact with the Galasa ecosystem or local development environment. Version 0.36.0"
+  desc "Command-line client for Galasa. Version 0.36.0"
   homepage "https://galasa.dev/"
 
   livecheck do

--- a/Casks/g/galasactl@0.37.0.rb
+++ b/Casks/g/galasactl@0.37.0.rb
@@ -9,7 +9,7 @@ cask "galasactl@0.37.0" do
   url "https://github.com/galasa-dev/cli/releases/download/v#{version}/galasactl-darwin-#{arch}",
       verified: "github.com/galasa-dev/cli/releases/"
   name "Galasa Client"
-  desc "Client to interact with the Galasa ecosystem or local development environment. Version 0.37.0"
+  desc "Command-line client for Galasa. Version 0.37.0"
   homepage "https://galasa.dev/"
 
   livecheck do

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `brew install galasa-dev/tap/<cask>`
 
-Or `brew tap galasa-dev/tap` and then `brew install <cask>`.
+Or `brew tap galasa-dev/tap` and then `brew install --no-quarantine <cask>`.
 
 ## Casks
 Currently different version of casks for the Galasa Command-Line interface (galasactl).  To install the latest version use the following command
@@ -20,7 +20,7 @@ brew install --no-quarantine galasactl@x.xx.x
 ```
 for example
 ```
-brew install --no-quarantine galasactl@0.36.0
+brew install --no-quarantine galasactl@0.37.0
 ```
 
 At the moment the --no-quarantine is required because otherwise its not possible to run the galasactl. See documentation about this at 
@@ -31,7 +31,7 @@ Use the helper script `add-version.sh`
 
 For example:
 ```bash
-./add-version.sh --version 0.36.0
+./add-version.sh --version 0.37.0
 ```
 
 The file Cask/g/galasactl.rb will be updated with that version, so people can get that as the latest version.

--- a/add-version.sh
+++ b/add-version.sh
@@ -156,9 +156,8 @@ EOF
 
 function update_readme_example() {
     h2 "Updating the example in the readme."
-    cat $BASEDIR/README.md | sed "s/brew install --no-quarantine galasactl@[0-9.]+/brew install --no-quarantine galasactl@${version_to_add}/1" > ${BASEDIR}/temp/README1.md
-    cat ${BASEDIR}/temp/README1.md | sed "s/add-version.sh --version .* /add-version.sh --version ${version_to_add}/1" > ${BASEDIR}/temp/README2.md
-    mv ${BASEDIR}/temp/README2.md ${BASEDIR}/README.md
+    cat $BASEDIR/README.md | sed -E "s/[0-9]+[0-9\.]*/${version_to_add}/g" > ${BASEDIR}/temp/README1.md
+    mv ${BASEDIR}/temp/README1.md ${BASEDIR}/README.md
     success "Readme updated OK."
 }
 


### PR DESCRIPTION
# Why ?
Noticed that the examples in the homebrew readme.md don't contain the latest version of things.

So now, if you run the add-version.sh --version 0.38.0 script, it should add update all the version numbers in the readme correctly.

I guess ideally we'd be doing this in the galasa-dev docs also to keep them current, but that's another story.