### PR TITLE
Iss2165 - Update URL to CLI binaries for brew instal

### DIFF
--- a/Casks/g/galasactl.rb
+++ b/Casks/g/galasactl.rb
@@ -6,8 +6,8 @@ cask "galasactl" do
   sha256 arm:   "061a424eb1cb2265e60465049774cc57f78de5d47636503a397493634275622e",
          intel: "c3faf4971118b8f7c2d6808af85ab3f6cc3b12d9cc17c713a606d04ddb8ea5db"
 
-  url "https://github.com/galasa-dev/cli/releases/download/v#{version}/galasactl-darwin-#{arch}",
-      verified: "github.com/galasa-dev/cli/releases/"
+  url "https://github.com/galasa-dev/galasa/releases/download/v#{version}/galasactl-darwin-#{arch}",
+      verified: "github.com/galasa-dev/galasa/releases/"
   name "Galasa Client"
   desc "Client to launch Galasa tests on a Galasa service or locally. Latest version"
   homepage "https://galasa.dev/"

--- a/Casks/g/galasactl@0.33.0.rb
+++ b/Casks/g/galasactl@0.33.0.rb
@@ -6,8 +6,8 @@ cask "galasactl@0.33.0" do
   sha256 arm:   "2965195ff7da084a3b60e48547f6ffc26bada6ae7bfebcf3c804041cd829f8cc",
          intel: "c60ab567dc246422507146460feb44f367e176bbfa69b33bdf232c56977f768e"
 
-  url "https://github.com/galasa-dev/cli/releases/download/v#{version}/galasactl-darwin-#{arch}",
-      verified: "github.com/galasa-dev/cli/releases/"
+  url "https://github.com/galasa-dev/galasa/releases/download/v#{version}/galasactl-darwin-#{arch}",
+      verified: "github.com/galasa-dev/galasa/releases/"
   name "Galasa Client"
   desc "Client to interact with the Galasa ecosystem or local development environment"
   homepage "https://galasa.dev/"

--- a/Casks/g/galasactl@0.34.0.rb
+++ b/Casks/g/galasactl@0.34.0.rb
@@ -6,8 +6,8 @@ cask "galasactl@0.34.0" do
   sha256 arm:   "f6db24d394dcda85d0a6c93d24279f0e99a149c842fb2628b13c82409f794fd0",
          intel: "47971b6d3427f4f3d9721ddcd98e6bfde73560d95df43f6a40837d6fd79f0f08"
 
-  url "https://github.com/galasa-dev/cli/releases/download/v#{version}/galasactl-darwin-#{arch}",
-      verified: "github.com/galasa-dev/cli/releases/"
+  url "https://github.com/galasa-dev/galasa/releases/download/v#{version}/galasactl-darwin-#{arch}",
+      verified: "github.com/galasa-dev/galasa/releases/"
   name "Galasa Client"
   desc "Client to interact with the Galasa ecosystem or local development environment"
   homepage "https://galasa.dev/"

--- a/Casks/g/galasactl@0.34.1.rb
+++ b/Casks/g/galasactl@0.34.1.rb
@@ -6,8 +6,8 @@ cask "galasactl@0.34.1" do
   sha256 arm:   "9336ff87dfe927a5fd07f5d59cffeb165680e4ce08ed199350810513b94ad85e",
          intel: "f3be42f09c4b1dc0765c8c381bbb73f7095aa2d133bbd5916763ee025401ba17"
 
-  url "https://github.com/galasa-dev/cli/releases/download/v#{version}/galasactl-darwin-#{arch}",
-      verified: "github.com/galasa-dev/cli/releases/"
+  url "https://github.com/galasa-dev/galasa/releases/download/v#{version}/galasactl-darwin-#{arch}",
+      verified: "github.com/galasa-dev/galasa/releases/"
   name "Galasa Client"
   desc "Client to interact with the Galasa ecosystem or local development environment"
   homepage "https://galasa.dev/"

--- a/Casks/g/galasactl@0.35.0.rb
+++ b/Casks/g/galasactl@0.35.0.rb
@@ -6,8 +6,8 @@ cask "galasactl@0.35.0" do
   sha256 arm:   "8bf6aa19fd5ea6e34c40379165892272c67f74c6b11992a9f1840cc72e79e08c",
          intel: "fc0f31701c06e1cfda03ed9c3303776a214cbab3d0d863a3ee4eaf6d5d40c0ff"
 
-  url "https://github.com/galasa-dev/cli/releases/download/v#{version}/galasactl-darwin-#{arch}",
-      verified: "github.com/galasa-dev/cli/releases/"
+  url "https://github.com/galasa-dev/galasa/releases/download/v#{version}/galasactl-darwin-#{arch}",
+      verified: "github.com/galasa-dev/galasa/releases/"
   name "Galasa Client"
   desc "Client to interact with the Galasa ecosystem or local development environment"
   homepage "https://galasa.dev/"

--- a/Casks/g/galasactl@0.36.0.rb
+++ b/Casks/g/galasactl@0.36.0.rb
@@ -6,8 +6,8 @@ cask "galasactl@0.36.0" do
   sha256 arm:   "d162571e1fa71d78f0d625d4feb6d17da21da54b5888f6fedc52902330accf98",
          intel: "a1ad08b22a1ca6f8f0755e34aec2a4b69ffee19450966753ba9a9f938c481653"
 
-  url "https://github.com/galasa-dev/cli/releases/download/v#{version}/galasactl-darwin-#{arch}",
-      verified: "github.com/galasa-dev/cli/releases/"
+  url "https://github.com/galasa-dev/galasa/releases/download/v#{version}/galasactl-darwin-#{arch}",
+      verified: "github.com/galasa-dev/galasa/releases/"
   name "Galasa Client"
   desc "Command-line client for Galasa. Version 0.36.0"
   homepage "https://galasa.dev/"

--- a/Casks/g/galasactl@0.37.0.rb
+++ b/Casks/g/galasactl@0.37.0.rb
@@ -6,8 +6,8 @@ cask "galasactl@0.37.0" do
   sha256 arm:   "5c4fe2c9e99af4ea21961c1b640a8a509b057eca37c27bfeb685d860c3b88b8c",
          intel: "2a019c7ad7c8158c12380a4a66293291d38fc553cc400caee89b8245263e2bc4"
 
-  url "https://github.com/galasa-dev/cli/releases/download/v#{version}/galasactl-darwin-#{arch}",
-      verified: "github.com/galasa-dev/cli/releases/"
+  url "https://github.com/galasa-dev/galasa/releases/download/v#{version}/galasactl-darwin-#{arch}",
+      verified: "github.com/galasa-dev/galasa/releases/"
   name "Galasa Client"
   desc "Command-line client for Galasa. Version 0.37.0"
   homepage "https://galasa.dev/"

--- a/Casks/g/galasactl@0.38.0.rb
+++ b/Casks/g/galasactl@0.38.0.rb
@@ -6,8 +6,8 @@ cask "galasactl@0.38.0" do
   sha256 arm:   "9197b02b7c232791900cbad5bed49f30a1f6e2154259e692416c8787d24a9d31",
          intel: "66d49325c4494c0585b734b070ca917e7da29c036b99348b754b435b66e134e3"
 
-  url "https://github.com/galasa-dev/cli/releases/download/v#{version}/galasactl-darwin-#{arch}",
-      verified: "github.com/galasa-dev/cli/releases/"
+  url "https://github.com/galasa-dev/galasa/releases/download/v#{version}/galasactl-darwin-#{arch}",
+      verified: "github.com/galasa-dev/galasa/releases/"
   name "Galasa Client"
   desc "Client to launch Galasa tests on a Galasa service or locally. Version 0.38.0"
   homepage "https://galasa.dev/"

--- a/Casks/g/galasactl@0.39.0.rb
+++ b/Casks/g/galasactl@0.39.0.rb
@@ -6,8 +6,8 @@ cask "galasactl@0.39.0" do
   sha256 arm:   "da5f15664b6bf780a9e5c996dd74bfb6da62a638c161d3bcc14d2635ab360ebe",
          intel: "c560b421baad70e30c90a9a4f3e9c547aaff567e43ac3302945767e02ccdc13a"
 
-  url "https://github.com/galasa-dev/cli/releases/download/v#{version}/galasactl-darwin-#{arch}",
-      verified: "github.com/galasa-dev/cli/releases/"
+  url "https://github.com/galasa-dev/galasa/releases/download/v#{version}/galasactl-darwin-#{arch}",
+      verified: "github.com/galasa-dev/galasa/releases/"
   name "Galasa Client"
   desc "Client to launch Galasa tests on a Galasa service or locally. Version 0.39.0"
   homepage "https://galasa.dev/"

--- a/Casks/g/galasactl@0.40.0.rb
+++ b/Casks/g/galasactl@0.40.0.rb
@@ -6,8 +6,8 @@ cask "galasactl@0.40.0" do
   sha256 arm:   "061a424eb1cb2265e60465049774cc57f78de5d47636503a397493634275622e",
          intel: "c3faf4971118b8f7c2d6808af85ab3f6cc3b12d9cc17c713a606d04ddb8ea5db"
 
-  url "https://github.com/galasa-dev/cli/releases/download/v#{version}/galasactl-darwin-#{arch}",
-      verified: "github.com/galasa-dev/cli/releases/"
+  url "https://github.com/galasa-dev/galasa/releases/download/v#{version}/galasactl-darwin-#{arch}",
+      verified: "github.com/galasa-dev/galasa/releases/"
   name "Galasa Client"
   desc "Client to launch Galasa tests on a Galasa service or locally. Version 0.40.0"
   homepage "https://galasa.dev/"

--- a/add-version.sh
+++ b/add-version.sh
@@ -98,8 +98,8 @@ cask "galasactl@${version_to_add}" do
   sha256 arm:   "${arm64_checksum}",
          intel: "${x86_checksum}"
 
-  url "https://github.com/galasa-dev/cli/releases/download/v#{version}/galasactl-darwin-#{arch}",
-      verified: "github.com/galasa-dev/cli/releases/"
+  url "https://github.com/galasa-dev/galasa/releases/download/v#{version}/galasactl-darwin-#{arch}",
+      verified: "github.com/galasa-dev/galasa/releases/"
   name "Galasa Client"
   desc "Client to launch Galasa tests on a Galasa service or locally. Version ${version_to_add}"
   homepage "https://galasa.dev/"
@@ -134,8 +134,8 @@ cask "galasactl" do
   sha256 arm:   "${arm64_checksum}",
          intel: "${x86_checksum}"
 
-  url "https://github.com/galasa-dev/cli/releases/download/v#{version}/galasactl-darwin-#{arch}",
-      verified: "github.com/galasa-dev/cli/releases/"
+  url "https://github.com/galasa-dev/galasa/releases/download/v#{version}/galasactl-darwin-#{arch}",
+      verified: "github.com/galasa-dev/galasa/releases/"
   name "Galasa Client"
   desc "Client to interact with the Galasa ecosystem or local development environment. Latest version."
   homepage "https://galasa.dev/"
@@ -191,7 +191,7 @@ h1 "Adding version $version_to_add"
 mkdir -p $BASEDIR/temp
 check_exit_code $? "couldn't  create a temporary folder"
 
-url_to_download_from=https://github.com/galasa-dev/cli/releases/download/v${version_to_add}/galasactl-darwin-x86_64
+url_to_download_from=https://github.com/galasa-dev/galasa/releases/download/v${version_to_add}/galasactl-darwin-x86_64
 
 # Work out the base name of the file we want to download.
 target_file_name=$(echo $url_to_download_from | sed "s/.*\///")
@@ -200,7 +200,7 @@ download_executable $url_to_download_from $target_file_path
 x86_checksum=$(shasum --algorithm 256 $target_file_path | cut -f1 -d' ')
 info "x86 checksum is $x86_checksum"
 
-url_to_download_from=https://github.com/galasa-dev/cli/releases/download/v${version_to_add}/galasactl-darwin-arm64
+url_to_download_from=https://github.com/galasa-dev/galasa/releases/download/v${version_to_add}/galasactl-darwin-arm64
 
 # Work out the base name of the file we want to download.
 target_file_name=$(echo $url_to_download_from | sed "s/.*\///")


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2165

Update the URLs to download the CLI binaries from to the galasa-dev/galasa repo from the galasa-dev/cli repo, now the source and Releases have been transferred over. The next CLI binary to be released will be from galasa-dev/galasa/releases.