### PR TITLE
Add 0.47.0 to homebrew tap

### DIFF
--- a/Casks/g/galasactl@0.47.0.rb
+++ b/Casks/g/galasactl@0.47.0.rb
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-cask "galasactl" do
+cask "galasactl@0.47.0" do
   arch arm: "arm64", intel: "x86_64"
 
   version "0.47.0"
@@ -15,7 +15,7 @@ cask "galasactl" do
   url "https://github.com/galasa-dev/galasa/releases/download/v#{version}/galasactl-darwin-#{arch}",
       verified: "github.com/galasa-dev/galasa/releases/"
   name "Galasa Client"
-  desc "Client to launch Galasa tests on a Galasa service or locally. Latest version"
+  desc "Client to launch Galasa tests on a Galasa service or locally. Version 0.47.0"
   homepage "https://galasa.dev/"
 
   livecheck do

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ brew install --no-quarantine galasactl@x.xx.x
 For example:
 
 ```bash
-brew install --no-quarantine galasactl@0.46.1
+brew install --no-quarantine galasactl@0.47.0
 ```
 
 > **Note:** The `--no-quarantine` flag is currently required because otherwise it's not possible to run the galasactl binary. See documentation about this at [https://galasa.dev](https://galasa.dev).
@@ -69,7 +69,7 @@ Use the helper script `add-version.sh` to add a new version:
 For example:
 
 ```bash
-./add-version.sh --version 0.46.1
+./add-version.sh --version 0.47.0
 ```
 
 This will:


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2528

## Changes
- [x] Added the 0.47.0 galasactl tool to the galasa-dev homebrew tap